### PR TITLE
Create magicdoor and building_magicdoor archs

### DIFF
--- a/mapbuilding/door.arc
+++ b/mapbuilding/door.arc
@@ -1,0 +1,21 @@
+Object magicdoor
+face wdoor.114
+animation mdoor_closed_1
+is_animated 0
+no_pick 1
+arch event_apply
+title Python
+slaying /python/items/magic_door.py
+end
+end
+
+Object building_magicdoor
+name magic door material
+nrof 1
+weight 150
+value 1500
+type 161
+subtype 2
+slaying magicdoor
+face wdoor.114
+end


### PR DESCRIPTION
Adds the `magicdoor` and `building_magicdoor` archetypes.

This is related to https://github.com/TitusCF/HeroWorld/pull/5